### PR TITLE
Guard recommended pairs and user profile on population of frequency data

### DIFF
--- a/src/components/TeamLayout/TeamMemberProfile/index.js
+++ b/src/components/TeamLayout/TeamMemberProfile/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import axios from "axios";
 import { API_URL } from "../../../constants";
 import { useParams } from "react-router-dom";
@@ -7,6 +7,7 @@ import ProfileCalendar from "./ProfileCalendar";
 import PairingSessionDuration from "./PairingSessionDuration";
 import PairingAcrossRoles from "./PairingAcrossRoles";
 import PrimaryRoleFrequencies from "./PrimaryRoleFrequencies";
+import { TeamContext } from "../TeamContext";
 import { subDays } from "date-fns";
 const MonthlyStats = ({ teamMember, monthly }) => {
   return (
@@ -23,6 +24,7 @@ const MonthlyStats = ({ teamMember, monthly }) => {
 };
 
 const TeamMemberProfile = () => {
+  const { frequency } = useContext(TeamContext);
   const { teamId, userId } = useParams();
   const [teamMember, setTeamMember] = useState(null);
 
@@ -32,7 +34,7 @@ const TeamMemberProfile = () => {
     });
   }, [setTeamMember, teamId, userId]);
 
-  if (!teamMember) {
+  if (!teamMember || !frequency) {
     return <h1 className="m-12">Loading...</h1>;
   }
   const today = new Date();

--- a/src/components/TeamLayout/TeamToday/PairGrid/Pair/recommendationHelper.js
+++ b/src/components/TeamLayout/TeamToday/PairGrid/Pair/recommendationHelper.js
@@ -31,6 +31,8 @@ export const leastPairedWith = (
   excluded,
   returnCount
 ) => {
+  if (!frequency) return [];
+
   const RETURN_COUNT = returnCount || 2;
   const userData = frequency.find((ud) => ud.username === teamMember.username);
   const roles = roleMapping(frequency);

--- a/src/components/TeamLayout/TeamToday/PairGrid/TeamMember.js
+++ b/src/components/TeamLayout/TeamToday/PairGrid/TeamMember.js
@@ -31,23 +31,27 @@ const Menu = ({ teamMember }) => {
           <span className="text-base font-light">View profile</span>
         </Link>
       </div>
-      <hr className="my-3 border-gray-300" />
-      <div className="py-1 px-2 rounded">
-        <div className="text-gray-900">
-          <span className="text-base text-center">Pair recommendations</span>
-        </div>
-        <div className="flex">
-          {recommendedList.map((name) => (
-            <div
-              key={name}
-              style={{ backgroundColor: roleColor(name) }}
-              className={`bg-gray-med w-8 h-8 mr-3 my-2 border-gray-border rounded-full flex items-center justify-center`}
-            >
-              <p className="text-white font-bold text-xs">{name}</p>
+      {recommendedList.length > 0 && (
+        <>
+          <hr className="my-3 border-gray-300" />
+          <div className="py-1 px-2 rounded">
+            <div className="text-gray-900">
+              <span className="text-base text-center">Pair recommendations</span>
             </div>
-          ))}
-        </div>
-      </div>
+            <div className="flex">
+              {recommendedList.map((name) => (
+                <div
+                  key={name}
+                  style={{ backgroundColor: roleColor(name) }}
+                  className={`bg-gray-med w-8 h-8 mr-3 my-2 border-gray-border rounded-full flex items-center justify-center`}
+                >
+                  <p className="text-white font-bold text-xs">{name}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Resolves #43 

Possible fix to address rendering errors. Seemed easier to guard the entire user profile on presence of frequency data, though it could technically be scoped to the two affected monthly stats if desired.